### PR TITLE
Fix #120: Resolve inaccurate radar distances for seated avatars in NearmeWithDetails

### DIFF
--- a/SecondBotEvents/Commands/Avatars.cs
+++ b/SecondBotEvents/Commands/Avatars.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using OpenMetaverse;
 using System.Text.Json;
@@ -83,14 +83,20 @@ namespace SecondBotEvents.Commands
             {
                 if (av.ID != GetClient().Self.AgentID)
                 {
+                    Vector3 globalPos = av.Position;
+                    if (av.ParentID != 0 && GetClient().Network.CurrentSim.ObjectsPrimitives.TryGetValue(av.ParentID, out Primitive parentObj))
+                    {
+                        globalPos = parentObj.Position + (av.Position * parentObj.Rotation);
+                    }
+
                     NearMeDetails details = new()
                     {
                         id = av.ID.ToString(),
                         name = av.Name,
-                        x = (int)Math.Round(av.Position.X),
-                        y = (int)Math.Round(av.Position.Y),
-                        z = (int)Math.Round(av.Position.Z),
-                        range = (int)Math.Round(Vector3.Distance(av.Position, GetClient().Self.SimPosition))
+                        x = (int)Math.Round(globalPos.X),
+                        y = (int)Math.Round(globalPos.Y),
+                        z = (int)Math.Round(globalPos.Z),
+                        range = Math.Round(Vector3.Distance(globalPos, GetClient().Self.SimPosition), 2)
                     };
                     BetterNearMe.Add(details);
                 }

--- a/SecondBotEvents/Commands/Core.cs
+++ b/SecondBotEvents/Commands/Core.cs
@@ -1,4 +1,4 @@
-﻿using SecondBotEvents.Services;
+using SecondBotEvents.Services;
 
 namespace SecondBotEvents.Commands
 {
@@ -28,7 +28,7 @@ namespace SecondBotEvents.Commands
         public int x { get; set; }
         public int y { get; set; }
         public int z { get; set; }
-        public int range { get; set; }
+        public double range { get; set; }
 
     }
 


### PR DESCRIPTION
Fixes #120

The Bug
When an avatar sits on an object or furniture, LibreMetaverse updates their Position property to be a local offset relative to the parent object (e.g., <0, 0, 0>), rather than their global simulator coordinates.

Because NearmeWithDetails was calculating Vector3.Distance between the bot's global SimPosition and the seated avatar's local Position, it resulted in wildly inaccurate distance math (often returning ranges of 100m to 400m+).

Why this broke Parcel Tracking: Because the bot relies on distance measurements to determine if an avatar is standing inside a specific parcel, these 400m+ hallucinations caused the bot to incorrectly assume seated avatars were completely outside the parcel boundaries. Consequently, the bot ignored them and failed to trigger GuestJoins events.

The Fix
In Avatars.cs, the NearmeWithDetails command now checks if the avatar has a ParentID (i.e., they are seated).
If they do, it queries the simulator's ObjectsPrimitives cache for the parent object and calculates the avatar's true global position by combining the parent's position, rotation, and the avatar's local offset.
range and x, y, z coordinates are now calculated against this true global position.
Updated the range property in NearMeDetails (Core.cs) from int to double and removed the aggressive integer cast in the math. It now returns the distance rounded to 2 decimal places for much higher precision tracking.
This restores accurate spatial tracking and allows parcel-level events to correctly fire for seated avatars!